### PR TITLE
feat(github-cli): add GitHub CLI installation task

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -55,6 +55,9 @@
     - import_tasks: tasks/docker.yml
       tags: [ docker ] 
 
+    - import_tasks: tasks/github-cli.yml
+      tags: [ github ] 
+
     - import_tasks: tasks/node-setup.yml
       tags: [ node ] 
 
@@ -62,4 +65,4 @@
       tags: [ rust ] 
 
     - import_tasks: tasks/k8s.yml
-      tags: [ k8s ] 
+      tags: [ k8s ]

--- a/tasks/github-cli.yml
+++ b/tasks/github-cli.yml
@@ -1,0 +1,41 @@
+- name: Ensure wget is installed
+  become: true
+  ansible.builtin.apt:
+    name: wget
+    state: present
+    update_cache: yes
+
+- name: Create keyrings directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add GitHub CLI's official GPG key
+  become: true
+  ansible.builtin.get_url:
+    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    mode: '0644'
+
+- name: Create sources.list.d directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d
+    state: directory
+    mode: '0755'
+
+- name: Add GitHub CLI repository to Apt sources
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ ansible_architecture }} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+    state: present
+    filename: github-cli
+
+- name: Install GitHub CLI
+  become: true
+  ansible.builtin.apt:
+    name: gh
+    state: present
+    update_cache: yes

--- a/tasks/github-cli.yml
+++ b/tasks/github-cli.yml
@@ -29,9 +29,10 @@
 - name: Add GitHub CLI repository to Apt sources
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb [arch={{ ansible_architecture }} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+    repo: "deb [arch={{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
     state: present
     filename: github-cli
+    update_cache: no
 
 - name: Install GitHub CLI
   become: true


### PR DESCRIPTION
## Summary
- Add new `tasks/github-cli.yml` file for installing GitHub CLI (gh)
- Update `local.yml` to include the GitHub CLI installation task with the `github` tag
- The installation is idempotent and supports both initial setup and updates

## Test plan
- [x] Run `ansible-playbook local.yml --tags github` to install GitHub CLI
- [x] Verify that `gh --version` works after installation
- [x] Run the playbook again to ensure idempotency
- [x] Test that the GPG key and repository are properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)